### PR TITLE
fix(Add APIs): return success message instead of just status

### DIFF
--- a/routes/addMember.js
+++ b/routes/addMember.js
@@ -9,7 +9,9 @@ router.post("/addmember", async (req, res) => {
     db.query(sqlQuery, [lastName, firstName, dob, email, mobile], function (err, _) {
       if (err) throw err;
 
-      return res.status(200);
+      return res.status(200).json({
+        message: "success",
+      });
     });
   } catch (error) {
     return res.status(400).json({

--- a/routes/addOrder.js
+++ b/routes/addOrder.js
@@ -9,7 +9,9 @@ router.post("/addorder", async (req, res) => {
     db.query(sqlQuery, [transaction_id, member_id, date_purchased], function (err, _) {
       if (err) throw err;
 
-      return res.status(200);
+      return res.status(200).json({
+        message: "success",
+      });
     });
   } catch (error) {
     return res.status(400).json({


### PR DESCRIPTION
Changes summary:
- Because the endpoints didn't return data (just status), the request kept hanging even after it's been processed
- Made endpoints return a short message on success